### PR TITLE
Fixing mockito dependency to be test only and dropwizard optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,12 @@
     </distributionManagement>
 
     <dependencies>
-        <!-- Dropwizard packages -->
+        <!-- Dropwizard logging package -->
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-logging</artifactId>
             <version>${dropwizard.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <!-- Logentries library to push our logs to their service -->
@@ -71,6 +72,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Mockito scope was incorrect, causing dependency conflicts in the dropwizard project.
Dropwizard dependency should be optional, as the dropwizard project will add dependency to it anyway.
